### PR TITLE
Set `priv->priv` before passing it through to `IP2Location_open_mem`.

### DIFF
--- a/src/vmod_ip2location.c
+++ b/src/vmod_ip2location.c
@@ -74,6 +74,7 @@ VPFX(init_db)(VRT_CTX, struct VPFX(priv) *priv, char *filename, char *memtype)
 	printf("The filename accepted is %s.\n", (char *) filename);	
 	
 	IP2Location *IP2LocationObj = IP2Location_open( (char *) filename);
+	priv->priv = IP2LocationObj;
 	// IP2Location_open_mem(priv->priv, IP2LOCATION_SHARED_MEMORY);
 	if (strcmp(memtype, "IP2LOCATION_FILE_IO") == 0) {
 		IP2Location_open_mem(priv->priv, IP2LOCATION_FILE_IO);
@@ -82,7 +83,7 @@ VPFX(init_db)(VRT_CTX, struct VPFX(priv) *priv, char *filename, char *memtype)
 	} else if (strcmp(memtype, "IP2LOCATION_SHARED_MEMORY") == 0) {
 		IP2Location_open_mem(priv->priv, IP2LOCATION_SHARED_MEMORY);
 	}
-	priv->priv = IP2LocationObj;
+
 	AN(priv->priv);
 	priv->free = i2pl_free;
 }


### PR DESCRIPTION
Without doing this we always passed a NULL value to the ip2location C library and we would always fall back to using the FILE method instead of CACHE or SHM.